### PR TITLE
[ETFE-1845] Add submission service and connector

### DIFF
--- a/app/connectors/emcsTfe/EmcsTfeHttpParser.scala
+++ b/app/connectors/emcsTfe/EmcsTfeHttpParser.scala
@@ -19,7 +19,7 @@ package connectors.emcsTfe
 import connectors.BaseConnectorUtils
 import models.{ErrorResponse, JsonValidationError, UnexpectedDownstreamResponseError}
 import play.api.http.Status.OK
-import play.api.libs.json.Writes
+import play.api.libs.json.{Json, Writes}
 import uk.gov.hmrc.http.{HeaderCarrier, HttpClient, HttpReads, HttpResponse}
 
 import scala.concurrent.{ExecutionContext, Future}
@@ -38,6 +38,7 @@ trait EmcsTfeHttpParser[A] extends BaseConnectorUtils[A] {
         }
         case status =>
           logger.warn(s"[read] Unexpected status from emcs-tfe: $status")
+          logger.debug(s"[read] Response body: \n\n${response.body}\n\n")
           Left(UnexpectedDownstreamResponseError)
       }
     }
@@ -46,6 +47,8 @@ trait EmcsTfeHttpParser[A] extends BaseConnectorUtils[A] {
   def get(url: String)(implicit hc: HeaderCarrier, ec: ExecutionContext): Future[Either[ErrorResponse, A]] =
     http.GET[Either[ErrorResponse, A]](url)(EmcsTfeReads, hc, ec)
 
-  def post[I](url: String, body: I)(implicit hc: HeaderCarrier, ec: ExecutionContext, writes: Writes[I]): Future[Either[ErrorResponse, A]] =
+  def post[I](url: String, body: I)(implicit hc: HeaderCarrier, ec: ExecutionContext, writes: Writes[I]): Future[Either[ErrorResponse, A]] = {
+    logger.debug(s"[post] url: '$url' with body: \n\n${Json.toJson(body)}\n\n")
     http.POST[I, Either[ErrorResponse, A]](url, body)(writes, EmcsTfeReads, hc, ec)
+  }
 }

--- a/app/connectors/emcsTfe/SubmitCancelMovementConnector.scala
+++ b/app/connectors/emcsTfe/SubmitCancelMovementConnector.scala
@@ -1,0 +1,47 @@
+/*
+ * Copyright 2023 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package connectors.emcsTfe
+
+import config.AppConfig
+import models.response.emcsTfe.SubmitCancelMovementResponse
+import models.submitCancelMovement.SubmitCancelMovementModel
+import models.{ErrorResponse, UnexpectedDownstreamResponseError}
+import play.api.libs.json.Reads
+import uk.gov.hmrc.http.{HeaderCarrier, HttpClient}
+
+import javax.inject.{Inject, Singleton}
+import scala.concurrent.{ExecutionContext, Future}
+
+@Singleton
+class SubmitCancelMovementConnector @Inject()(val http: HttpClient,
+                                              config: AppConfig) extends EmcsTfeHttpParser[SubmitCancelMovementResponse] {
+
+  override implicit val reads: Reads[SubmitCancelMovementResponse] = SubmitCancelMovementResponse.format
+
+  lazy val baseUrl: String = config.emcsTfeBaseUrl
+
+  def submit(ern: String, submitCancelMovementModel: SubmitCancelMovementModel)
+            (implicit headerCarrier: HeaderCarrier, executionContext: ExecutionContext): Future[Either[ErrorResponse, SubmitCancelMovementResponse]] = {
+    post(s"$baseUrl/cancel-movement/$ern/${submitCancelMovementModel.arc}", submitCancelMovementModel)
+
+  }.recover {
+    ex =>
+      logger.warn(s"[submit] Unexpected response from emcs-tfe : ${ex.getMessage}")
+      Left(UnexpectedDownstreamResponseError)
+  }
+
+}

--- a/app/models/CancelReason.scala
+++ b/app/models/CancelReason.scala
@@ -17,6 +17,7 @@
 package models
 
 import play.api.i18n.Messages
+import play.api.libs.json.{JsString, Writes}
 import uk.gov.hmrc.govukfrontend.views.Aliases.Text
 import uk.gov.hmrc.govukfrontend.views.viewmodels.radios.RadioItem
 
@@ -49,4 +50,12 @@ object CancelReason extends Enumerable.Implicits {
 
   implicit val enumerable: Enumerable[CancelReason] =
     Enumerable(values.map(v => v.toString -> v): _*)
+
+  val submissionWrites: Writes[CancelReason] = Writes {
+    case Other => JsString("0")
+    case ContainsError => JsString("1")
+    case TransactionInterrupted => JsString("2")
+    case Duplicate => JsString("3")
+    case DifferentDispatchDate => JsString("4")
+  }
 }

--- a/app/models/DestinationType.scala
+++ b/app/models/DestinationType.scala
@@ -27,6 +27,9 @@ object DestinationType extends Enumerable.Implicits {
   case object ExemptedOrganisations extends WithName("5") with DestinationType
   case object Export extends WithName("6") with DestinationType
   case object UnknownDestination extends WithName("8") with DestinationType
+  case object CertifiedConsignee extends WithName("9") with DestinationType
+  case object TemporaryCertifiedConsignee extends WithName("10") with DestinationType
+  case object ReturnToThePlaceOfDispatchOfTheConsignor extends WithName("11") with DestinationType
 
   val values: Seq[DestinationType] = Seq(
     TaxWarehouse,
@@ -35,7 +38,10 @@ object DestinationType extends Enumerable.Implicits {
     DirectDelivery,
     ExemptedOrganisations,
     Export,
-    UnknownDestination
+    UnknownDestination,
+    CertifiedConsignee,
+    TemporaryCertifiedConsignee,
+    ReturnToThePlaceOfDispatchOfTheConsignor
   )
 
   implicit val enumerable: Enumerable[DestinationType] =

--- a/app/models/audit/SubmitCancelMovementAuditModel.scala
+++ b/app/models/audit/SubmitCancelMovementAuditModel.scala
@@ -1,0 +1,59 @@
+/*
+ * Copyright 2023 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package models.audit
+
+import models.ErrorResponse
+import models.requests.DataRequest
+import models.response.emcsTfe.SubmitCancelMovementResponse
+import models.submitCancelMovement.SubmitCancelMovementModel
+import play.api.libs.json.{JsValue, Json}
+import utils.JsonOptionFormatter
+
+case class SubmitCancelMovementAuditModel(
+                                           submissionRequest: SubmitCancelMovementModel,
+                                           submissionResponse: Either[ErrorResponse, SubmitCancelMovementResponse]
+                                         )(implicit request: DataRequest[_]) extends AuditModel with JsonOptionFormatter {
+
+  override val auditType: String = "cancelMovementSubmission"
+
+  override val detail: JsValue = jsonObjNoNulls(fields =
+    "credentialId" -> request.credId,
+    "internalId" -> request.internalId,
+    "ern" -> request.ern,
+    "arc" -> submissionRequest.arc,
+    "sequenceNumber" -> submissionRequest.sequenceNumber,
+    "consigneeTrader" -> Json.toJson(submissionRequest.consigneeTrader),
+    "destinationType" -> Json.toJson(submissionRequest.destinationType),
+    "memberStateCode" -> Json.toJson(submissionRequest.memberStateCode),
+    "cancelReason" -> Json.toJson(submissionRequest.cancelReason),
+    "additionalInformation" -> Json.toJson(submissionRequest.additionalInformation)
+  ) ++ {
+    submissionResponse match {
+      case Right(success) =>
+        Json.obj(fields =
+          "status" -> "success",
+          "receipt" -> success.receipt,
+          "receiptDate" -> success.receiptDate
+        )
+      case Left(failedMessage) =>
+        Json.obj(fields =
+          "status" -> "failed",
+          "failedMessage" -> failedMessage.message
+        )
+    }
+  }
+}

--- a/app/models/common/AddressModel.scala
+++ b/app/models/common/AddressModel.scala
@@ -14,19 +14,15 @@
  * limitations under the License.
  */
 
-package models.requests
+package models.common
 
-import models.UserAnswers
-import models.response.emcsTfe.GetMovementResponse
-import play.api.mvc.WrappedRequest
+import play.api.libs.json.{Format, Json}
 
-case class DataRequest[A](request: MovementRequest[A],
-                          userAnswers: UserAnswers) extends WrappedRequest[A](request) {
+case class AddressModel(streetNumber: Option[String],
+                        street: Option[String],
+                        postcode: Option[String],
+                        city: Option[String])
 
-  val credId: String = request.request.credId
-  val internalId: String = request.internalId
-  val ern: String = request.ern
-  val arc: String = request.arc
-  val movementDetails: GetMovementResponse = request.movementDetails
-
+object AddressModel {
+  implicit val fmt: Format[AddressModel] = Json.format
 }

--- a/app/models/common/TraderModel.scala
+++ b/app/models/common/TraderModel.scala
@@ -14,11 +14,11 @@
  * limitations under the License.
  */
 
-package models.response.emcsTfe
+package models.common
 
 import play.api.libs.json.{Format, Json}
 
-case class TraderModel(traderId: Option[String],
+case class TraderModel(traderExciseNumber: Option[String],
                        traderName: Option[String],
                        address: Option[AddressModel],
                        eoriNumber: Option[String])

--- a/app/models/response/emcsTfe/GetMovementResponse.scala
+++ b/app/models/response/emcsTfe/GetMovementResponse.scala
@@ -17,6 +17,7 @@
 package models.response.emcsTfe
 
 import models.DestinationType
+import models.common.TraderModel
 import play.api.libs.json.{Json, Reads}
 
 import java.time.LocalDate
@@ -26,10 +27,11 @@ case class GetMovementResponse(arc: String,
                                sequenceNumber: Int,
                                destinationType: DestinationType,
                                consigneeTrader: Option[TraderModel],
+                               memberStateCode: Option[String],
                                deliveryPlaceTrader: Option[TraderModel],
                                localReferenceNumber: String,
                                eadStatus: String,
-                               consignorTrader: ConsignorTraderModel,
+                               consignorTrader: TraderModel,
                                dateOfDispatch: LocalDate,
                                journeyTime: String,
                                numberOfItems: Int) {

--- a/app/models/response/emcsTfe/SubmitCancelMovementResponse.scala
+++ b/app/models/response/emcsTfe/SubmitCancelMovementResponse.scala
@@ -18,11 +18,8 @@ package models.response.emcsTfe
 
 import play.api.libs.json.{Format, Json}
 
-case class AddressModel(streetNumber: Option[String],
-                        street: Option[String],
-                        postcode: Option[String],
-                        city: Option[String])
+case class SubmitCancelMovementResponse(receipt: String, receiptDate: String)
 
-object AddressModel {
-  implicit val fmt: Format[AddressModel] = Json.format
+object SubmitCancelMovementResponse {
+  implicit val format: Format[SubmitCancelMovementResponse] = Json.format
 }

--- a/app/models/submitCancelMovement/SubmitCancelMovementModel.scala
+++ b/app/models/submitCancelMovement/SubmitCancelMovementModel.scala
@@ -1,0 +1,63 @@
+/*
+ * Copyright 2023 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package models.submitCancelMovement
+
+import models.common.TraderModel
+import models.response.emcsTfe.GetMovementResponse
+import models.{CancelReason, DestinationType, UserAnswers}
+import pages.{CancelReasonPage, MoreInformationPage}
+import play.api.libs.json.{Json, Writes}
+import utils.{JsonOptionFormatter, ModelConstructorHelpers}
+
+case class SubmitCancelMovementModel(arc: String,
+                                     sequenceNumber: Int,
+                                     cancelReason: CancelReason,
+                                     additionalInformation: Option[String],
+                                     consigneeTrader: Option[TraderModel],
+                                     destinationType: DestinationType,
+                                     memberStateCode: Option[String])
+
+object SubmitCancelMovementModel extends JsonOptionFormatter with ModelConstructorHelpers {
+
+  def apply(movementDetails: GetMovementResponse)(implicit userAnswers: UserAnswers): SubmitCancelMovementModel =
+    SubmitCancelMovementModel(
+      arc = movementDetails.arc,
+      sequenceNumber = movementDetails.sequenceNumber,
+      cancelReason = mandatoryPage(CancelReasonPage),
+      additionalInformation = userAnswers.get(MoreInformationPage).flatten,
+      consigneeTrader = movementDetails.consigneeTrader,
+      destinationType = movementDetails.destinationType,
+      memberStateCode = movementDetails.memberStateCode
+    )
+
+  implicit val fmt: Writes[SubmitCancelMovementModel] = Writes { model =>
+    jsonObjNoNulls(
+      "exciseMovement" -> Json.obj(
+        "arc" -> model.arc,
+        "sequenceNumber" -> model.sequenceNumber
+      ),
+      "cancellationReason" -> jsonObjNoNulls(
+        "reason" -> Json.toJson(model.cancelReason)(CancelReason.submissionWrites),
+        "complementaryInformation" -> Json.toJson(model.additionalInformation)
+      ),
+      "consigneeTrader" -> Json.toJson(model.consigneeTrader),
+      "destinationType" -> Json.toJson(model.destinationType),
+      "memberStateCode" -> Json.toJson(model.memberStateCode)
+    )
+  }
+
+}

--- a/app/models/submitCancelMovement/SubmitterType.scala
+++ b/app/models/submitCancelMovement/SubmitterType.scala
@@ -14,19 +14,20 @@
  * limitations under the License.
  */
 
-package models.requests
+package models.submitCancelMovement
 
-import models.UserAnswers
-import models.response.emcsTfe.GetMovementResponse
-import play.api.mvc.WrappedRequest
+import models.{Enumerable, WithName}
 
-case class DataRequest[A](request: MovementRequest[A],
-                          userAnswers: UserAnswers) extends WrappedRequest[A](request) {
+sealed trait SubmitterType
 
-  val credId: String = request.request.credId
-  val internalId: String = request.internalId
-  val ern: String = request.ern
-  val arc: String = request.arc
-  val movementDetails: GetMovementResponse = request.movementDetails
+object SubmitterType extends Enumerable.Implicits {
 
+  case object Consignor extends WithName("1") with SubmitterType
+
+  case object Consignee extends WithName("2") with SubmitterType
+
+  val values: Seq[SubmitterType] = Seq(Consignor, Consignee)
+
+  implicit val enumerable: Enumerable[SubmitterType] =
+    Enumerable(values.map(v => v.toString -> v): _*)
 }

--- a/app/services/SubmitCancelMovementService.scala
+++ b/app/services/SubmitCancelMovementService.scala
@@ -1,0 +1,60 @@
+/*
+ * Copyright 2023 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package services
+
+import connectors.emcsTfe.SubmitCancelMovementConnector
+import models.audit.SubmitCancelMovementAuditModel
+import models.submitCancelMovement.SubmitCancelMovementModel
+import models.requests.DataRequest
+import models.response.emcsTfe.SubmitCancelMovementResponse
+import models.{ErrorResponse, SubmitCancelMovementException}
+import uk.gov.hmrc.http.HeaderCarrier
+import utils.Logging
+
+import javax.inject.{Inject, Singleton}
+import scala.concurrent.{ExecutionContext, Future}
+
+@Singleton
+class SubmitCancelMovementService @Inject()(submitShortageOrExcessConnector: SubmitCancelMovementConnector,
+                                            auditingService: AuditingService)
+                                           (implicit ec: ExecutionContext) extends Logging {
+
+  def submit(ern: String, arc: String)(implicit hc: HeaderCarrier, dataRequest: DataRequest[_]): Future[SubmitCancelMovementResponse] = {
+
+    val submissionRequest = SubmitCancelMovementModel(dataRequest.movementDetails)(dataRequest.userAnswers)
+
+    submitShortageOrExcessConnector.submit(ern, submissionRequest).map {
+      withAuditEvent(submissionRequest, _)
+        .getOrElse(throw SubmitCancelMovementException(s"Failed to submit Cancel Movement to emcs-tfe for ern: '$ern' & arc: '$arc'"))
+    }
+  }
+
+  private def withAuditEvent(submissionRequest: SubmitCancelMovementModel,
+                             submissionResponse: Either[ErrorResponse, SubmitCancelMovementResponse])
+                            (implicit hc: HeaderCarrier, dataRequest: DataRequest[_]): Either[ErrorResponse, SubmitCancelMovementResponse] = {
+    if(submissionResponse.isLeft) {
+      logger.warn(s"[submit] Failed to submit Cancel Movement to emcs-tfe for ern: '${dataRequest.ern}' and arc: '${dataRequest.arc}'")
+    }
+    auditingService.audit(
+      SubmitCancelMovementAuditModel(
+        submissionRequest = submissionRequest,
+        submissionResponse = submissionResponse
+      )
+    )
+    submissionResponse
+  }
+}

--- a/app/utils/JsonOptionFormatter.scala
+++ b/app/utils/JsonOptionFormatter.scala
@@ -16,7 +16,7 @@
 
 package utils
 
-import play.api.libs.json.{Format, JsNull, JsResult, JsValue, Writes}
+import play.api.libs.json._
 
 trait JsonOptionFormatter {
 
@@ -28,6 +28,9 @@ trait JsonOptionFormatter {
       case None ⇒ JsNull
     }
   }
+
+  def jsonObjNoNulls(fields: (String, Json.JsValueWrapper)*): JsObject =
+    JsObject(Json.obj(fields: _*).fields.filterNot(_._2 == JsNull).filterNot(_._2 == Json.obj()))
 }
 
 object JsonOptionFormatter extends JsonOptionFormatter

--- a/it/connectors/SubmitCancelMovementConnectorISpec.scala
+++ b/it/connectors/SubmitCancelMovementConnectorISpec.scala
@@ -1,0 +1,100 @@
+package connectors
+
+import com.github.tomakehurst.wiremock.client.WireMock._
+import com.github.tomakehurst.wiremock.http.Fault
+import connectors.emcsTfe.SubmitCancelMovementConnector
+import fixtures.SubmitCancelMovementFixtures
+import generators.ModelGenerators
+import models.UnexpectedDownstreamResponseError
+import org.scalatest.concurrent.{IntegrationPatience, ScalaFutures}
+import org.scalatest.freespec.AnyFreeSpec
+import org.scalatest.matchers.must.Matchers
+import org.scalatest.{EitherValues, OptionValues}
+import org.scalatestplus.mockito.MockitoSugar
+import play.api.Application
+import play.api.http.Status.{INTERNAL_SERVER_ERROR, NOT_FOUND, OK}
+import play.api.inject.guice.GuiceApplicationBuilder
+import play.api.libs.json.Json
+import play.api.test.Helpers.AUTHORIZATION
+import uk.gov.hmrc.http.HeaderCarrier
+
+import scala.concurrent.ExecutionContext.Implicits.global
+
+class SubmitCancelMovementConnectorISpec extends AnyFreeSpec
+  with WireMockHelper
+  with ScalaFutures
+  with Matchers
+  with IntegrationPatience
+  with EitherValues
+  with OptionValues
+  with MockitoSugar
+  with ModelGenerators
+  with SubmitCancelMovementFixtures {
+
+  implicit private lazy val hc: HeaderCarrier = HeaderCarrier()
+
+  private lazy val app: Application =
+    new GuiceApplicationBuilder()
+      .configure(
+        "microservice.services.emcs-tfe.port" -> server.port,
+        "internal-auth.token" -> "token"
+      )
+      .build()
+
+  private lazy val connector: SubmitCancelMovementConnector = app.injector.instanceOf[SubmitCancelMovementConnector]
+
+  ".submit" - {
+
+    val url = s"/emcs-tfe/cancel-movement/$testErn/$testArc"
+    val body = Json.toJson(successResponseJson)
+
+    "must return true when the server responds OK" in {
+
+      server.stubFor(
+        post(urlEqualTo(url))
+          .withRequestBody(equalToJson(Json.stringify(Json.toJson(submitCancelMovementModel))))
+          .willReturn(aResponse().withStatus(OK).withBody(Json.stringify(body)))
+      )
+
+      connector.submit("ern", submitCancelMovementModel).futureValue mustBe Right(successResponse)
+    }
+
+    "must return false when the server responds NOT_FOUND" in {
+
+      server.stubFor(
+        post(urlEqualTo(url))
+          .withHeader(AUTHORIZATION, equalTo("token"))
+          .withRequestBody(equalToJson(Json.stringify(Json.toJson(body))))
+          .willReturn(aResponse().withStatus(NOT_FOUND))
+      )
+
+      connector.submit("ern", submitCancelMovementModel).futureValue mustBe Left(UnexpectedDownstreamResponseError)
+    }
+
+    "must fail when the server responds with any other status" in {
+
+      server.stubFor(
+        post(urlEqualTo(url))
+          .withHeader(AUTHORIZATION, equalTo("token"))
+          .withRequestBody(equalToJson(Json.stringify(Json.toJson(body))))
+          .willReturn(aResponse().withStatus(INTERNAL_SERVER_ERROR))
+      )
+
+      connector.submit("ern", submitCancelMovementModel).futureValue mustBe Left(UnexpectedDownstreamResponseError)
+    }
+
+    "must fail when the connection fails" in {
+
+      server.stubFor(
+        post(urlEqualTo(url))
+          .withHeader(AUTHORIZATION, equalTo("token"))
+          .withRequestBody(equalToJson(Json.stringify(Json.toJson(body))))
+          .willReturn(aResponse().withFault(Fault.RANDOM_DATA_THEN_CLOSE))
+      )
+
+      connector.submit("ern", submitCancelMovementModel).futureValue mustBe Left(UnexpectedDownstreamResponseError)
+    }
+  }
+
+
+}

--- a/test-utils/fixtures/GetMovementResponseFixtures.scala
+++ b/test-utils/fixtures/GetMovementResponseFixtures.scala
@@ -17,7 +17,8 @@
 package fixtures
 
 import models.DestinationType.TaxWarehouse
-import models.response.emcsTfe.{AddressModel, ConsignorTraderModel, GetMovementResponse}
+import models.common.{AddressModel, TraderModel}
+import models.response.emcsTfe.GetMovementResponse
 import play.api.libs.json.{JsValue, Json}
 
 import java.time.LocalDate
@@ -29,18 +30,20 @@ trait GetMovementResponseFixtures { _: BaseFixtures =>
     sequenceNumber = 1,
     destinationType = TaxWarehouse,
     consigneeTrader = None,
+    memberStateCode = Some("GB"),
     deliveryPlaceTrader = None,
     localReferenceNumber = "MyLrn",
     eadStatus = "MyEadStatus",
-    consignorTrader = ConsignorTraderModel(
-      traderExciseNumber = "GB12345GTR144",
-      traderName = "MyConsignor",
-      address = AddressModel(
+    consignorTrader = TraderModel(
+      traderExciseNumber = Some("GB12345GTR144"),
+      traderName = Some("MyConsignor"),
+      address = Some(AddressModel(
         streetNumber = None,
         street = Some("Main101"),
         postcode = Some("ZZ78"),
         city = Some("Zeebrugge")
-      )
+      )),
+      None
     ),
     dateOfDispatch = LocalDate.parse("2010-03-04"),
     journeyTime = "MyJourneyTime",
@@ -51,6 +54,7 @@ trait GetMovementResponseFixtures { _: BaseFixtures =>
     "arc" -> testArc,
     "sequenceNumber" -> 1,
     "destinationType" -> "1",
+    "memberStateCode" -> "GB",
     "localReferenceNumber" -> "MyLrn",
     "eadStatus" -> "MyEadStatus",
     "consignorTrader" -> Json.obj(fields =

--- a/test-utils/fixtures/SubmitCancelMovementFixtures.scala
+++ b/test-utils/fixtures/SubmitCancelMovementFixtures.scala
@@ -1,0 +1,40 @@
+/*
+ * Copyright 2023 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package fixtures
+
+import models.CancelReason.Other
+import models.DestinationType.TaxWarehouse
+import models.response.emcsTfe.SubmitCancelMovementResponse
+import models.submitCancelMovement.SubmitCancelMovementModel
+import play.api.libs.json.Json
+
+trait SubmitCancelMovementFixtures extends BaseFixtures {
+
+  val submitCancelMovementModel = SubmitCancelMovementModel(
+    arc = testArc,
+    sequenceNumber = 1,
+    cancelReason = Other,
+    additionalInformation = Some("more information about explaining the delay"),
+    consigneeTrader = None,
+    destinationType = TaxWarehouse,
+    memberStateCode = Some("GB")
+  )
+
+  val successResponse = SubmitCancelMovementResponse(receipt = testConfirmationReference, receiptDate = testReceiptDate)
+
+  val successResponseJson = Json.obj("receipt" -> testConfirmationReference, "receiptDate" -> testReceiptDate)
+}

--- a/test-utils/fixtures/audit/SubmitCancelMovementAuditModelFixtures.scala
+++ b/test-utils/fixtures/audit/SubmitCancelMovementAuditModelFixtures.scala
@@ -1,0 +1,71 @@
+/*
+ * Copyright 2023 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package fixtures.audit
+
+import fixtures.{BaseFixtures, GetMovementResponseFixtures, SubmitCancelMovementFixtures}
+import models.UnexpectedDownstreamResponseError
+import models.audit.SubmitCancelMovementAuditModel
+import models.requests.{DataRequest, MovementRequest, UserRequest}
+import play.api.libs.json.{JsValue, Json}
+import play.api.test.FakeRequest
+import utils.JsonOptionFormatter.jsonObjNoNulls
+
+trait SubmitCancelMovementAuditModelFixtures extends BaseFixtures
+  with SubmitCancelMovementFixtures
+  with GetMovementResponseFixtures {
+
+  val submitCancelMovementAuditSuccessful: SubmitCancelMovementAuditModel = SubmitCancelMovementAuditModel(
+    submissionRequest = submitCancelMovementModel,
+    submissionResponse = Right(successResponse)
+  )(DataRequest(MovementRequest(UserRequest(FakeRequest(), testErn, testInternalId, testCredId), testArc, getMovementResponseModel), emptyUserAnswers))
+
+  val submitCancelMovementAuditSuccessfulJSON: JsValue = jsonObjNoNulls(
+    "credentialId" -> testCredId,
+    "internalId" -> testInternalId,
+    "ern" -> testErn,
+    "arc" -> testArc,
+    "sequenceNumber" -> 1,
+    "consigneeTrader" -> Json.toJson(submitCancelMovementModel.consigneeTrader),
+    "destinationType" -> Json.toJson(submitCancelMovementModel.destinationType),
+    "memberStateCode" -> Json.toJson(submitCancelMovementModel.memberStateCode),
+    "cancelReason" -> Json.toJson(submitCancelMovementModel.cancelReason),
+    "additionalInformation" -> Json.toJson(submitCancelMovementModel.additionalInformation),
+    "status" -> "success",
+    "receipt" -> testConfirmationReference,
+    "receiptDate" -> testReceiptDate
+  )
+
+  val submitCancelMovementAuditFailed: SubmitCancelMovementAuditModel = SubmitCancelMovementAuditModel(
+    submissionRequest = submitCancelMovementModel,
+    submissionResponse = Left(UnexpectedDownstreamResponseError)
+  )(DataRequest(MovementRequest(UserRequest(FakeRequest(), testErn, testInternalId, testCredId), testArc, getMovementResponseModel), emptyUserAnswers))
+
+  val submitCancelMovementAuditFailedJSON: JsValue = jsonObjNoNulls(
+    "credentialId" -> testCredId,
+    "internalId" -> testInternalId,
+    "ern" -> testErn,
+    "arc" -> testArc,
+    "sequenceNumber" -> 1,
+    "consigneeTrader" -> Json.toJson(submitCancelMovementModel.consigneeTrader),
+    "destinationType" -> Json.toJson(submitCancelMovementModel.destinationType),
+    "memberStateCode" -> Json.toJson(submitCancelMovementModel.memberStateCode),
+    "cancelReason" -> Json.toJson(submitCancelMovementModel.cancelReason),
+    "additionalInformation" -> Json.toJson(submitCancelMovementModel.additionalInformation),
+    "status" -> "failed",
+    "failedMessage" -> "Unexpected downstream response status"
+  )
+}

--- a/test/mocks/connectors/MockSubmitCancelMovementConnector.scala
+++ b/test/mocks/connectors/MockSubmitCancelMovementConnector.scala
@@ -1,0 +1,40 @@
+/*
+ * Copyright 2023 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package mocks.connectors
+
+import connectors.emcsTfe.SubmitCancelMovementConnector
+import models.ErrorResponse
+import models.response.emcsTfe.SubmitCancelMovementResponse
+import models.submitCancelMovement.SubmitCancelMovementModel
+import org.scalamock.handlers.CallHandler4
+import org.scalamock.scalatest.MockFactory
+import uk.gov.hmrc.http.HeaderCarrier
+
+import scala.concurrent.{ExecutionContext, Future}
+
+trait MockSubmitCancelMovementConnector extends MockFactory {
+
+  lazy val mockSubmitCancelMovementConnector: SubmitCancelMovementConnector = mock[SubmitCancelMovementConnector]
+
+  object MockSubmitCancelMovementConnector {
+
+    def submit(ern: String,
+               submission: SubmitCancelMovementModel): CallHandler4[String, SubmitCancelMovementModel, HeaderCarrier, ExecutionContext, Future[Either[ErrorResponse, SubmitCancelMovementResponse]]] =
+      (mockSubmitCancelMovementConnector.submit(_: String, _: SubmitCancelMovementModel)(_: HeaderCarrier, _: ExecutionContext))
+        .expects(ern, submission, *, *)
+  }
+}

--- a/test/mocks/services/MockSubmitCancelMovementService.scala
+++ b/test/mocks/services/MockSubmitCancelMovementService.scala
@@ -1,0 +1,44 @@
+/*
+ * Copyright 2023 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package mocks.services
+
+import models.UserAnswers
+import models.requests.DataRequest
+import models.response.emcsTfe.{GetMovementResponse, SubmitCancelMovementResponse}
+import org.scalamock.handlers.CallHandler4
+import org.scalamock.scalatest.MockFactory
+import services.SubmitCancelMovementService
+import uk.gov.hmrc.http.HeaderCarrier
+
+import scala.concurrent.Future
+
+trait MockSubmitCancelMovementService extends MockFactory {
+
+  lazy val mockSubmitCancelMovementService: SubmitCancelMovementService = mock[SubmitCancelMovementService]
+
+  object MockSubmitCancelMovementService {
+
+    def submit(ern: String, arc: String, movement: GetMovementResponse, userAnswers: UserAnswers)
+    : CallHandler4[String, String, HeaderCarrier, DataRequest[_], Future[SubmitCancelMovementResponse]] =
+      (mockSubmitCancelMovementService.submit(_: String, _: String)(_: HeaderCarrier, _: DataRequest[_]))
+        .expects(where {
+          (_ern: String, _arc: String, _: HeaderCarrier, request: DataRequest[_]) => {
+            _ern == ern && _arc == arc && request.movementDetails == movement && request.userAnswers == userAnswers
+          }
+        })
+  }
+}

--- a/test/models/CancelReasonSpec.scala
+++ b/test/models/CancelReasonSpec.scala
@@ -22,7 +22,7 @@ import org.scalatestplus.scalacheck.ScalaCheckPropertyChecks
 import org.scalatest.freespec.AnyFreeSpec
 import org.scalatest.matchers.must.Matchers
 import org.scalatest.OptionValues
-import play.api.libs.json.{JsError, JsString, Json}
+import play.api.libs.json.{JsError, JsString, Json, Writes}
 
 class CancelReasonSpec extends AnyFreeSpec with Matchers with ScalaCheckPropertyChecks with OptionValues {
 
@@ -30,7 +30,7 @@ class CancelReasonSpec extends AnyFreeSpec with Matchers with ScalaCheckProperty
 
     "must deserialise valid values" in {
 
-      val gen = Gen.oneOf(CancelReason.values.toSeq)
+      val gen = Gen.oneOf(CancelReason.values)
 
       forAll(gen) {
         cancelReason =>
@@ -52,13 +52,24 @@ class CancelReasonSpec extends AnyFreeSpec with Matchers with ScalaCheckProperty
 
     "must serialise" in {
 
-      val gen = Gen.oneOf(CancelReason.values.toSeq)
+      val gen = Gen.oneOf(CancelReason.values)
 
       forAll(gen) {
         cancelReason =>
 
           Json.toJson(cancelReason) mustEqual JsString(cancelReason.toString)
       }
+    }
+
+    "have submissionWrites with the correct mapping" in {
+
+      implicit val writes: Writes[CancelReason] = CancelReason.submissionWrites
+
+      Json.toJson[CancelReason](CancelReason.Other) mustBe JsString("0")
+      Json.toJson[CancelReason](CancelReason.ContainsError) mustBe JsString("1")
+      Json.toJson[CancelReason](CancelReason.TransactionInterrupted) mustBe JsString("2")
+      Json.toJson[CancelReason](CancelReason.Duplicate) mustBe JsString("3")
+      Json.toJson[CancelReason](CancelReason.DifferentDispatchDate) mustBe JsString("4")
     }
   }
 }

--- a/test/models/audit/SubmitCancelMovementAuditModelSpec.scala
+++ b/test/models/audit/SubmitCancelMovementAuditModelSpec.scala
@@ -14,17 +14,24 @@
  * limitations under the License.
  */
 
-package models.response.emcsTfe
+package models.audit
 
+import base.SpecBase
+import fixtures.audit.SubmitCancelMovementAuditModelFixtures
 
-import play.api.libs.json.{Format, Json}
+class SubmitCancelMovementAuditModelSpec extends SpecBase with SubmitCancelMovementAuditModelFixtures {
 
-case class ConsignorTraderModel(traderExciseNumber: String,
-                                traderName: String,
-                                address: AddressModel) {
-}
+  "SubmitCancelMovementAuditModel" - {
 
-object ConsignorTraderModel {
+    "should write a correct audit json" - {
 
-  implicit val fmt: Format[ConsignorTraderModel] = Json.format
+      "when a successful submission has occurred" in {
+        submitCancelMovementAuditSuccessful.detail mustBe submitCancelMovementAuditSuccessfulJSON
+      }
+
+      "when a failed to submit has occurred" in {
+        submitCancelMovementAuditFailed.detail mustBe submitCancelMovementAuditFailedJSON
+      }
+    }
+  }
 }

--- a/test/models/submitCancelMovement/SubmitCancelMovementModelSpec.scala
+++ b/test/models/submitCancelMovement/SubmitCancelMovementModelSpec.scala
@@ -1,0 +1,107 @@
+/*
+ * Copyright 2023 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package models.submitCancelMovement
+
+import base.SpecBase
+import fixtures.GetMovementResponseFixtures
+import models.CancelReason.Duplicate
+import models.DestinationType.TaxWarehouse
+import models.common.{AddressModel, TraderModel}
+import pages.{CancelReasonPage, ChooseGiveMoreInformationPage, MoreInformationPage}
+import play.api.libs.json.Json
+
+class SubmitCancelMovementModelSpec extends SpecBase with GetMovementResponseFixtures {
+
+  "SubmitCancelMovementModel" - {
+
+    val userAnswers = emptyUserAnswers
+      .set(CancelReasonPage, Duplicate)
+      .set(ChooseGiveMoreInformationPage, true)
+      .set(MoreInformationPage, Some("more information"))
+
+    "can be constructed from combination of UserAnswers and MovementDetails as expected" in {
+
+      SubmitCancelMovementModel(getMovementResponseModel)(userAnswers) mustBe
+        SubmitCancelMovementModel(
+          arc = testArc,
+          sequenceNumber = 1,
+          cancelReason = Duplicate,
+          additionalInformation = Some("more information"),
+          consigneeTrader = None,
+          destinationType = TaxWarehouse,
+          memberStateCode = Some("GB")
+        )
+    }
+
+    "should write to JSON as expected to match Submission API" - {
+
+      "for max values" in {
+
+        Json.toJson(SubmitCancelMovementModel(getMovementResponseModel.copy(
+          consigneeTrader = Some(TraderModel(
+            traderExciseNumber = Some(testErn),
+            traderName = Some("TraderName"),
+            address = Some(AddressModel(
+              streetNumber = Some("1"),
+              street = Some("Street Name"),
+              postcode = Some("TF3 4ER"),
+              city = Some("Telford")
+            )),
+            eoriNumber = None
+          ))
+        ))(userAnswers)) mustBe
+          Json.obj(
+            "exciseMovement" -> Json.obj(
+              "arc" -> testArc,
+              "sequenceNumber" -> 1
+            ),
+            "cancellationReason" -> Json.obj(
+              "reason" -> "3",
+              "complementaryInformation" -> "more information"
+            ),
+            "consigneeTrader" -> Json.obj(
+              "traderExciseNumber" -> testErn,
+              "traderName" -> "TraderName",
+              "address" -> Json.obj(
+                "streetNumber" -> "1",
+                "street" -> "Street Name",
+                "postcode" -> "TF3 4ER",
+                "city" -> "Telford"
+              )
+            ),
+            "destinationType" -> "1",
+            "memberStateCode" -> "GB"
+          )
+      }
+
+      "for min values" in {
+
+        Json.toJson(SubmitCancelMovementModel(getMovementResponseModel.copy(memberStateCode = None))(userAnswers.remove(MoreInformationPage))) mustBe
+          Json.obj(
+            "exciseMovement" -> Json.obj(
+              "arc" -> testArc,
+              "sequenceNumber" -> 1
+            ),
+            "cancellationReason" -> Json.obj(
+              "reason" -> "3"
+            ),
+            "destinationType" -> "1"
+          )
+      }
+    }
+  }
+}

--- a/test/services/SubmitCancelMovementServiceSpec.scala
+++ b/test/services/SubmitCancelMovementServiceSpec.scala
@@ -1,0 +1,92 @@
+/*
+ * Copyright 2023 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package services
+
+import base.SpecBase
+import fixtures.SubmitCancelMovementFixtures
+import mocks.connectors.MockSubmitCancelMovementConnector
+import mocks.services.MockAuditingService
+import models.CancelReason.Other
+import models.{SubmitCancelMovementException, UnexpectedDownstreamResponseError}
+import models.audit.SubmitCancelMovementAuditModel
+import models.submitCancelMovement.SubmitCancelMovementModel
+import pages.{CancelReasonPage, ChooseGiveMoreInformationPage, MoreInformationPage}
+import play.api.test.FakeRequest
+import play.api.test.Helpers.{await, defaultAwaitTimeout}
+import uk.gov.hmrc.http.HeaderCarrier
+
+import scala.concurrent.{ExecutionContext, Future}
+
+class SubmitCancelMovementServiceSpec extends SpecBase
+  with MockSubmitCancelMovementConnector
+  with SubmitCancelMovementFixtures
+  with MockAuditingService {
+
+  implicit val hc = HeaderCarrier()
+  implicit val ec = ExecutionContext.global
+
+  lazy val testService = new SubmitCancelMovementService(mockSubmitCancelMovementConnector, mockAuditingService)
+
+  val userAnswers = emptyUserAnswers
+    .set(CancelReasonPage, Other)
+    .set(MoreInformationPage, Some("reason"))
+
+  ".submit(ern: String, submission: SubmitCancelMovementModel)" - {
+
+    "should submit, audit and return a success response" - {
+
+      "when connector receives a success from downstream" in {
+
+        val request = dataRequest(FakeRequest(), userAnswers)
+
+        val submission = SubmitCancelMovementModel(getMovementResponseModel)(userAnswers)
+
+        MockSubmitCancelMovementConnector.submit(testErn, submission).returns(Future.successful(Right(successResponse)))
+
+        MockAuditingService.audit(
+          SubmitCancelMovementAuditModel(
+            submission,
+            Right(successResponse)
+          )(dataRequest(FakeRequest()))
+        ).noMoreThanOnce()
+
+        testService.submit(testErn, testArc)(hc, request).futureValue mustBe successResponse
+      }
+    }
+
+    "should submit, audit and return a failure response" - {
+
+      "when connector receives a failure from downstream" in {
+
+        val request = dataRequest(FakeRequest(), userAnswers)
+        val submission = SubmitCancelMovementModel(getMovementResponseModel)(userAnswers)
+
+        MockSubmitCancelMovementConnector.submit(testErn, submission).returns(Future.successful(Left(UnexpectedDownstreamResponseError)))
+
+        MockAuditingService.audit(
+          SubmitCancelMovementAuditModel(
+            submission,
+            Left(UnexpectedDownstreamResponseError)
+          )(dataRequest(FakeRequest()))
+        ).noMoreThanOnce()
+
+        intercept[SubmitCancelMovementException](await(testService.submit(testErn, testArc)(hc, request))).getMessage mustBe
+          s"Failed to submit Cancel Movement to emcs-tfe for ern: '$testErn' & arc: '$testArc'"
+      }
+    }
+  }
+}


### PR DESCRIPTION
**Notes:**
- Includes initial placeholder audit event, although this needs to be confirmed with CIP and any changes updated under a separate story
- dependent BE PR needs to be reviewed and merged to return the MemberStateCode:
  - https://github.com/hmrc/emcs-tfe/pull/72